### PR TITLE
ok 2025-05 is done

### DIFF
--- a/app.pianocheetah.pianocheetah.json
+++ b/app.pianocheetah.pianocheetah.json
@@ -3,7 +3,7 @@
    "command": "pianocheetah",
    "sdk":     "org.kde.Sdk",
    "runtime": "org.kde.Platform",
-   "runtime-version": "6.6",
+   "runtime-version": "6.9",
    "finish-args": [
       "--filesystem=host",
       "--share=ipc",
@@ -25,7 +25,7 @@
             {
                "type": "git",
                "url": "https://github.com/Stephen-Hazel/pc_build.git",
-               "commit": "f488b7bcf6d9be5fce165e2a3cec5c94b664f075"
+               "commit": "a35519e29d3d3ef025eec211b903a45f659af62c"
             }
          ]
       }


### PR DESCRIPTION
per title.  using kde runtime 6.9 now.  syn has glide(portamento) and envelopes.
new live record in hear mode.
huge bug killing last release solved now that i know about it.
